### PR TITLE
Fix bug where nothing ever rotates

### DIFF
--- a/internal/provider/multi_rotate_set_resource.go
+++ b/internal/provider/multi_rotate_set_resource.go
@@ -217,11 +217,7 @@ func (r *MultiRotateSet) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		data.RotationSet = stateData.RotationSet
 	}
 
-	now, err := time.Parse(time.RFC3339, data.Timestamp.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Invalid Current Time", "Unable to parse current time: "+err.Error())
-		return
-	}
+	now := time.Now()
 
 	lr, err := time.Parse(time.RFC3339, data.LastRotate.ValueString())
 	if err != nil {


### PR DESCRIPTION
Fixes this bug: https://github.com/mixpanel/terraform-provider-multirotate/issues/11

The bug was caused since the stored terraform state timestamp was used to check whenever a rotation should happen. Since that value was always in the past, behind the expiration date a rotation was never performed. When using the current timestamp it now always works for me. I have tested it using the following terraform code with a `.terraformrc` dev override.

```terraform
terraform {
  required_providers {
    multirotate = {
      source = "hashicorp.com/edu/multirotate"
    }
  }
}

resource "multirotate_set" "token_rotation" {
  rotation_period = "10s"
  number          = 2
}

resource "local_file" "example" {
  count    = multirotate_set.token_rotation.number
  filename = "file1-${count.index}"
  content  = multirotate_set.token_rotation.rotation_set[count.index].expiration
}
```

```
provider_installation {
  dev_overrides {
    "hashicorp.com/edu/multirotate" = "<MY_HOME_DIR>/go/bin"
  }
  direct {}
}
```
Closes #11 